### PR TITLE
Fix gotnet images tags

### DIFF
--- a/multistage examples/Dockerfile
+++ b/multistage examples/Dockerfile
@@ -12,7 +12,7 @@ WORKDIR /app/aspnetapp
 RUN dotnet publish -c Release -o out
 
 
-FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
+FROM mcr.microsoft.com/dotnet/aspnet:3.1 AS build
 WORKDIR /app
 COPY --from=build /app/aspnetapp/out ./
 ENTRYPOINT ["dotnet", "aspnetapp.dll"]

--- a/multistage examples/Dockerfile
+++ b/multistage examples/Dockerfile
@@ -1,4 +1,4 @@
-FROM microsoft/dotnet:2.1-sdk AS build
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
 WORKDIR /app
 
 # copy csproj and restore as distinct layers
@@ -12,7 +12,7 @@ WORKDIR /app/aspnetapp
 RUN dotnet publish -c Release -o out
 
 
-FROM microsoft/dotnet:2.1-aspnetcore-runtime AS runtime
+FROM mcr.microsoft.com/dotnet/sdk:3.1 AS build
 WORKDIR /app
 COPY --from=build /app/aspnetapp/out ./
 ENTRYPOINT ["dotnet", "aspnetapp.dll"]

--- a/multistage examples/aspnetapp/aspnetapp.csproj
+++ b/multistage examples/aspnetapp/aspnetapp.csproj
@@ -1,12 +1,8 @@
 <Project Sdk="Microsoft.NET.Sdk.Web">
 
   <PropertyGroup>
-    <TargetFramework>netcoreapp2.1</TargetFramework>
+    <TargetFramework>netcoreapp3.1</TargetFramework>
     <UserSecretsId>31051026529000467138</UserSecretsId>
   </PropertyGroup>
-
-  <ItemGroup>
-    <PackageReference Include="Microsoft.AspNetCore.App" />
-  </ItemGroup>
 
 </Project>


### PR DESCRIPTION
There are new tags for dotnet images:

> https://hub.docker.com/_/microsoft-dotnet-sdk/
> https://hub.docker.com/_/microsoft-dotnet-runtime/
> https://hub.docker.com/_/microsoft-dotnet-aspnet/